### PR TITLE
Fixed Data change for X-Plane 11

### DIFF
--- a/lib/xplane.js
+++ b/lib/xplane.js
@@ -35,7 +35,7 @@ util.inherits(XPlane, EventEmitter);
 XPlane.prototype.onUDPData = function(rawBuffer) {
   var self = this;
   // check for DATA@
-  if (rawBuffer.toString('ascii', 0, 5) == 'DATA@') {
+  if (rawBuffer.toString('ascii', 0, 5) == 'DATA*') {
     var dataBuffer = rawBuffer.slice(5, 5 + rawBuffer.length - (rawBuffer.length % 36))
       , buf = dataBuffer.slice(0, 36);
     for (var offset = 0; offset < dataBuffer.length; offset += 36, buf = dataBuffer.slice(offset, offset+36)) {


### PR DESCRIPTION
Due to a change in the code for X-Plane 11's 5th bit to an `*` instead of a `@` the application has stopped working. This fixes the issue.